### PR TITLE
Added the ability to truncate/empty a cohort before managing members

### DIFF
--- a/cli/cohortmembersync.php
+++ b/cli/cohortmembersync.php
@@ -41,6 +41,7 @@ list($options, $unrecognized) = cli_get_params(
             'flatfileencoding' => false,
             'cohortidentifier' => false,
             'useridentifier' => false,
+			'truncatefirst' => false,
             'verbose' => false),
         array(
             'h' => 'help',
@@ -49,6 +50,7 @@ list($options, $unrecognized) = cli_get_params(
             'e' => 'flatfileencoding',
             'c' => 'cohortidentifier',
             'u' => 'useridentifier',
+			't' => 'truncatefirst',
             'v' => 'verbose')
 );
 
@@ -72,6 +74,8 @@ if ($options['help']) {
     -u, --useridentifier      The column used to identify user in the database
                               These idetenfiers are considered: username, id, idnumber
                               Default: the value defined in the plugin setting
+    -t  --truncatefirst       Truncate/Empty the cohort first. Cohort is chosen from the first data line (supposed use is one file / cohort).
+                              Default: no truncate
     -v, --verbose             Print verbose progress information
 
     Example:

--- a/lang/en/tool_cohortsync.php
+++ b/lang/en/tool_cohortsync.php
@@ -28,7 +28,9 @@ $string['cohortsyncheader'] = 'Cohort configuration';
 $string['cohortidentifier'] = 'Cohort identifier';
 $string['cohortidentifierdesc'] = 'This parameter is used to identify the cohort in which to insert the member.';
 $string['cohortmembersyncheader'] = 'Cohort member configuration';
+$string['cohorttruncated'] = 'Cohort "{$a}" truncated at the beginning';
 $string['csvdelimiter'] = 'CSV delimiter';
+$string['emptydata'] = 'Empty or wrong data';
 $string['encoding'] = 'Encoding';
 $string['errordefaultcontext'] = 'Default context does not exist';
 $string['errordelimiterfile'] = 'Only these delimeters are allowed: comma, semicolon, colon, tab';
@@ -38,6 +40,7 @@ $string['flatfiledelimiter'] = 'Flatfile delimiter';
 $string['formatcsv'] = 'CSV file format';
 $string['formatcsvdesc'] = '';
 $string['pluginname'] = 'Cohort synchronization';
+$string['truncatefirst'] = 'Empty cohort first';
 $string['useridentifier'] = 'User identifier';
 $string['useridentifierdesc'] = 'This parameter is used to identify the user who will be added to the cohort.';
 

--- a/settings.php
+++ b/settings.php
@@ -64,7 +64,6 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
             1,
             $contextoptions));
 
-    $choices = csv_import_reader::get_delimiter_list();
     $settings->add(new admin_setting_configselect('tool_cohortsync/truncatefirst',
 	get_string('truncatefirst', 'tool_cohortsync'), '', 'yes', array('yes','no')));
 

--- a/settings.php
+++ b/settings.php
@@ -64,6 +64,10 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
             1,
             $contextoptions));
 
+    $choices = csv_import_reader::get_delimiter_list();
+    $settings->add(new admin_setting_configselect('tool_cohortsync/truncatefirst',
+	get_string('truncatefirst', 'tool_cohortsync'), '', 'yes', array('yes','no')));
+
     // Cohort member configuration.
     $settings->add(new admin_setting_heading('cohortmembersyncheader',
             get_string('cohortmembersyncheader', 'tool_cohortsync'), ''));


### PR DESCRIPTION
It comes with a new option and a special behavior when switched on.
The cohort of the first line of the flat file to sync is emptied before adding the members.
I did some tests on my moodle where I needed it because I'm able to generate the proper groups from scratch every day.
I also modified the lowercase code I mentioned in the issue I opened.
If you are still concerned by this tool, I'm open to any improvement on my code suggestion.
Good evening.